### PR TITLE
There is no need to kill it completely, just step it down

### DIFF
--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -127,16 +127,17 @@ function getShardConfig() {
 }
 
 function killMaster() {
-    replTest.stopMaster();
+    // Step down for 5seconds, and prevent elections for 6 seconds so we can do some tests without primary
+    printjson(replTest.getMaster().getDB("admin")._adminCommand({ replSetStepDown: 5, force: true }));
+    printjson(replTest.getMaster().getDB("admin")._adminCommand({ replSetFreeze: 6 }));
 }
 function killRS() {
     replTest.stopSet();
 }
 
 function restartMaster() {
-    replTest.start(0, {remember: true}, true)
-    conn = replTest.liveNodes.slaves[1]
-    ReplSetTest.awaitRSClientHosts(conn, replTest, replTest.nodes)
+    // Just wait until we get a master
+    printjson(replTest.getMaster());
 }
 
 


### PR DESCRIPTION
This reduces the crazy amount of time the failover tests require
